### PR TITLE
feat(Download): Added the possibility to specify scryfall's sorting direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ cards make sure to use MID and not PMID!
 
 # Config.ini
 - You can choose the download folder and cards.txt naming conventions.
+- You can choose whether to download newest card versions or oldest (this applies only to cards for which a set code is not specified).
 - You can choose whether to download all available arts or only one art.
 - You can choose whether to only download unique art or all art even when duplicats are present.
 - You can choose whether to ignore fullarts (supported only when download all is enabled)

--- a/config.ini
+++ b/config.ini
@@ -16,6 +16,7 @@ Download.All = false
 Overwrite.Same.Name = true
 
 [SEARCH]
+If.No.Set.Code.Get.Newest = true
 Only.Search.Unique.Art = true
 Exclude.Fullart = false
 Include.Extras = true

--- a/main.py
+++ b/main.py
@@ -170,6 +170,7 @@ class Download:
                 "unique": cfg.unique,
                 "include_extras": cfg.include_extras,
                 "order": "released",
+                "dir": cfg.release_sorting,
                 "q": f'!"{card}"',
             }
         )

--- a/src/settings.py
+++ b/src/settings.py
@@ -74,6 +74,13 @@ download_all = config.getboolean("SETTINGS", "Download.All", fallback=False)
 SEARCH SETTINGS
 """
 
+# In which direction should the sorting by release date occur (this applies only to cards for which no set is specified)?
+release_sorting = (
+    "desc"
+    if config.getboolean("SEARCH", "If.No.Set.Code.Get.Newest", fallback=True)
+    else "asc"
+)
+
 # Exclude full arts?
 exclude_fullart = config.getboolean("SEARCH", "Exclude.Fullart", fallback=False)
 


### PR DESCRIPTION
added the possibility to specify scryfall's direction to sort cards by release date (this applies only to cards for which no set code is specified)